### PR TITLE
フッタとリンク部分の被り修正

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,7 +32,7 @@
     </div>
     <footer id="footer">
       <div class="container">
-        <p class="credit">copyright 2010-2013 Hiroshima.rb</p>
+        <p><small>copyright 2010-2013 Hiroshima.rb</small></p>
       </div>
     </footer>
     <script src="http://code.jquery.com/jquery.js"></script>

--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -4,27 +4,24 @@ body {
 
 html,
 body {
-    height: 100%;
+	margin: 0;
+	padding: 0;
+	
 }
 
-hgroup {
+header {
+	width: 100%;
+	margin-bottom: 30px;
     background-color: #9E005D;
-    margin: -10px 0 40px 0;
-    padding: 40px 0 20px 40px;
     color: white;
-}
-
-@media (max-width: 767px) {
-    hgroup {
-        margin-left: -20px;
-        margin-right: -20px;
-        padding-left: 20px;
-        padding-right: 20px;
-    }
 }
 
 h1 {
     margin: 20px;
+}
+
+hgroup{
+	padding: 20px;
 }
 
 hgroup h1 {
@@ -39,25 +36,21 @@ hgroup h2 {
 }
 
 #wrap {
+	width: 100%;
+	margin: 0;
+	padding: 0;
 }
 
 #footer {
+	width: 100%;
+	height: 44px;
+	line-height: 44px;
     background-color: #9E005D;
     color: white;
-    height: 44px;
 }
 
-@media (max-width: 767px) {
-    #footer {
-        margin-left: -20px;
-        margin-right: -20px;
-        padding-left: 20px;
-        padding-right: 20px;
-    }
-}
-
-.credit {
-    margin: 14px 0;
+#footer .container{
+	padding: 0 10px;
 }
 
 .hidden {


### PR DESCRIPTION
テストを兼ねたプルリクエスト
コンテンツ内のリンク部分がフッタに被っているのを解消しました

Bootstrapの挙動を制御して、ネガティブマージンをGOOD BYE!
これで、メディアクエリがなくても大丈夫だと思います。
